### PR TITLE
update snapshots to match expected template

### DIFF
--- a/apps/site/jest.config.ts
+++ b/apps/site/jest.config.ts
@@ -1,5 +1,11 @@
 /* eslint-disable */
-export default {
+import nextJest from "next/jest";
+
+const createJestConfig = nextJest({
+  dir: __dirname,
+})
+
+export default createJestConfig({
   displayName: 'site',
   preset: '../../jest.preset.js',
   transform: {
@@ -8,4 +14,4 @@ export default {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/site',
-};
+});

--- a/apps/site/specs/index.spec.tsx
+++ b/apps/site/specs/index.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-
+import nextJest from 'next/jest';
 import Link from "next/link";
 
 describe("Index", () => {
@@ -14,6 +14,7 @@ describe("Index", () => {
       <div>
         <a
           href="https://example.com"
+          data-testid="link"
         >
           Link element with new behavior
         </a>
@@ -29,11 +30,16 @@ describe("Index", () => {
     );
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <strong
-          data-testid="content"
+        <a 
+          href="https://example.com"
+          data-testid="link"
         >
-          Link element with new behavior
-        </strong>
+          <strong
+            data-testid="content"
+          >
+            Link element with new behavior
+          </strong>
+        </a>
       </div>
     `);
   });


### PR DESCRIPTION
```
npx jest --clear-cache && npx nx test site --skip-nx-cache
Cleared /private/var/folders/ws/_4mjt9x975g1z4r61kwm6c8r0000gn/T/jest_dx

> nx run site:test

 FAIL   site  apps/site/specs/index.spec.tsx
  Index
    ✕ should render <Link> element with new behavior (14 ms)
    ✕ should render <Link> element with nested child with new behavior (4 ms)
    ✓ should render <Link> element with legacy behavior (5 ms)

  ● Index › should render <Link> element with new behavior

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `Index should render <Link> element with new behavior 1`

    - Snapshot  - 1
    + Received  + 0

      <div>
        <a
          href="https://example.com"
    -     data-testid="link"
        >
          Link element with new behavior
        </a>
      </div>

      11 |       </Link>
      12 |     );
    > 13 |     expect(container).toMatchInlineSnapshot(`
         |                       ^
      14 |       <div>
      15 |         <a
      16 |           href="https://example.com"

      at Object.<anonymous> (specs/index.spec.tsx:13:23)

  ● Index › should render <Link> element with nested child with new behavior

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `Index should render <Link> element with nested child with new behavior 1`

    - Snapshot  - 5
    + Received  + 0

      <div>
    -   <a
    -     href="https://example.com"
    -     data-testid="link"
    -   >
        <strong
          data-testid="content"
        >
          Link element with new behavior
        </strong>
    -   </a>
      </div>

      29 |       </Link>
      30 |     );
    > 31 |     expect(container).toMatchInlineSnapshot(`
         |                       ^
      32 |       <div>
      33 |         <a
      34 |           href="https://example.com"

      at Object.<anonymous> (specs/index.spec.tsx:31:23)

 › 2 snapshots failed.
Snapshot Summary
 › 2 snapshots failed from 1 test suite. Inspect your code changes or re-run jest with `-u` to update them.

Test Suites: 1 failed, 1 total
Tests:       2 failed, 1 passed, 3 total
Snapshots:   2 failed, 1 passed, 3 total
Time:        0.634 s
Ran all test suites.

 —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Ran target test for project site (1s)

    ✖    1/1 failed
    ✔    0/1 succeeded [0 read from cache]

   See Nx Cloud run details at https://nx.app/runs/gt7E05xLdI

```